### PR TITLE
context增加abort函数

### DIFF
--- a/lualib/wlua/context.lua
+++ b/lualib/wlua/context.lua
@@ -46,6 +46,11 @@ function M:next()
     end
 end
 
+--中断调用,比如中间件验证失败
+function M:abort()
+    self.index = #self.handlers + 1
+end
+
 -- M:send(text, status, content_type)
 function M:send(...)
     self.res:send(...)


### PR DESCRIPTION
有时候需要在中间件层中断函数流动，比如鉴权失败